### PR TITLE
chore: setup crates.io publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,29 @@
+name: Publish to crates.io
+
+on:
+  release:
+    types: [published]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --verbose
+
+      - name: Publish to crates.io
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "trickery"
 version = "0.1.0"
 edition = "2021"
+description = "CLI tool for generating textual artifacts using LLM"
+authors = ["Mykhailo Chalyi"]
+license-file = "LICENSE"
+repository = "https://github.com/chaliy/trickery"
+readme = "README.md"
+keywords = ["cli", "llm", "openai", "template", "codegen"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 clap = { version = "^4.5.43", features = ["derive"] }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -57,9 +57,13 @@ pub enum Role {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContentPart {
-    Text { text: String },
+    Text {
+        text: String,
+    },
     #[allow(dead_code)] // For future image support
-    ImageUrl { image_url: ImageUrl },
+    ImageUrl {
+        image_url: ImageUrl,
+    },
 }
 
 /// Image URL for vision models
@@ -294,7 +298,12 @@ mod tests {
     #[test]
     fn test_content_part_text() {
         let part = ContentPart::text("Hello");
-        assert_eq!(part, ContentPart::Text { text: "Hello".to_string() });
+        assert_eq!(
+            part,
+            ContentPart::Text {
+                text: "Hello".to_string()
+            }
+        );
     }
 
     #[test]

--- a/src/provider/openai.rs
+++ b/src/provider/openai.rs
@@ -27,8 +27,7 @@ impl OpenAIProvider {
     pub fn from_env() -> Result<Self, ProviderError> {
         let api_key = env::var("OPENAI_API_KEY")
             .map_err(|_| ProviderError::MissingApiKey("OPENAI_API_KEY".to_string()))?;
-        let base_url =
-            env::var("OPENAI_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        let base_url = env::var("OPENAI_BASE_URL").unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
 
         Ok(Self {
             client: Client::new(),
@@ -120,9 +119,10 @@ impl OpenAIProvider {
         }
 
         let api_response: OpenAIResponse = response.json().await?;
-        let choice = api_response.choices.into_iter().next().ok_or_else(|| {
-            ProviderError::InvalidResponse("No choices in response".to_string())
-        })?;
+        let choice =
+            api_response.choices.into_iter().next().ok_or_else(|| {
+                ProviderError::InvalidResponse("No choices in response".to_string())
+            })?;
 
         Ok(CompletionResponse {
             content: choice.message.content,
@@ -208,9 +208,9 @@ impl OpenAIMessage {
                 parts
                     .iter()
                     .map(|p| match p {
-                        ContentPart::Text { text } => OpenAIContentPart::Text {
-                            text: text.clone(),
-                        },
+                        ContentPart::Text { text } => {
+                            OpenAIContentPart::Text { text: text.clone() }
+                        }
                         ContentPart::ImageUrl { image_url } => OpenAIContentPart::ImageUrl {
                             image_url: OpenAIImageUrl {
                                 url: image_url.url.clone(),


### PR DESCRIPTION
## What
Add crates.io publishing configuration and automated release workflow.

## Why
Enable distribution of trickery as a crate for easy installation via `cargo install trickery`.

## How
- Add required metadata to Cargo.toml (description, authors, license-file, repository, readme, keywords, categories)
- Add GitHub Actions workflow that publishes to crates.io on release

## Risk
- Low
- Requires `CARGO_REGISTRY_TOKEN` secret to be configured before first release

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [ ] Documentation is updated