### PR TITLE
docs: update install instructions to use cargo install trickery

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)
 
+
 cli to generate textual artifacts using LLM.
 
 Idea is simple, imagine you need to generate some docs using LLM as part of CI, this is a tool for you.
@@ -15,7 +16,7 @@ Idea is simple, imagine you need to generate some docs using LLM as part of CI, 
 If you have rust/cargo installed, you can install `trickery` with:
 
 ```sh
-cargo install --git https://github.com/chaliy/trickery.git
+cargo install trickery
 trickery --help
 ```
 
@@ -26,19 +27,12 @@ export OPENAI_API_KEY=s....d
 trickery generate -i ./prompts/trickery_readme.md > README.md
 ```
 
-Input file could be any text file, with Jinja2-like template variables, like `{{app_version}}`. To set this variables, please use `-v` flag, like `-v app_version=1.0.0`.
+Input file could be any text file, with Jinja2-like template variables, like `{{"{{app_version}}"}}`. To set this variables, please use `-v` flag, like `-v app_version=1.0.0`.
 
 ## Українською 🇺🇦
 
-Trickery — це маленький інструмент командного рядка для генерації текстових артефактів за допомогою великих мовних моделей (LLM). Його ідея дуже проста: якщо вам потрібно автоматично згенерувати документацію, реліз-ноти або інші текстові файли в процесі CI/CD, trickery дозволяє зробити це легко, підставивши змінні в шаблонах та викликавши модель для генерації вмісту. Інструмент орієнтований на простоту використання та інтеграцію в існуючі скрипти і пайплайни.
-
-- Підтримувані шаблони: будь-які текстові файли з Jinja2-подібними змінними (`{{name}}`)
-- Налаштування через параметри `-v` (наприклад `-v app_version=1.0.0`)
-- Працює добре в CI: можна експортувати ключі та викликати з консолі
-
-Будь ласка, повідомляйте про баги та пропозиції в репозиторії, будемо раді внеску.
+Цей інструмент дозволяє зручно та автоматично генерувати текстові артефакти (документацію, описові файли тощо) за допомогою великих мовних моделей. Ідея проста: інтегруйте генерацію у ваш CI/CD або виконуйте локально, підставляючи змінні у шаблони. Будь ласка, використовуйте інструмент відповідально та перевіряйте згенерований контент перед публікацією.
 
 ## Dad Joke
 
-Why did the developer go broke? Because he used up all his cache.
-
+Why did the developer bring a ladder to work? Because they heard the code needed to be taken to the next level.

--- a/prompts/trickery_readme.md
+++ b/prompts/trickery_readme.md
@@ -26,7 +26,7 @@ Idea is simple, imagine you need to generate some docs using LLM as part of CI, 
 If you have rust/cargo installed, you can install `trickery` with:
 
 ```sh
-cargo install --git https://github.com/chaliy/trickery.git
+cargo install trickery
 trickery --help
 ```
 


### PR DESCRIPTION
## Summary
- Updated README template to use `cargo install trickery` instead of installing from git
- Regenerated README.md with the simplified installation instructions

## Why
The package is now published on crates.io, so users can install directly without needing to reference the git repository.

## Test plan
- [x] Verified `cargo install trickery` is the correct command for crates.io installation
- [x] Regenerated README successfully with trickery
