### PR TITLE
chore: add MSRV 1.75 to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "trickery"
 version = "0.1.1"
 edition = "2021"
+rust-version = "1.75"
 description = "CLI tool for generating textual artifacts using LLM"
 authors = ["Mykhailo Chalyi"]
 license-file = "LICENSE"


### PR DESCRIPTION
## What
Adds `rust-version = "1.75"` to Cargo.toml to specify the Minimum Supported Rust Version.

## Why
Communicates to users and tooling the minimum Rust version required to build the project.

## How
Single line addition to Cargo.toml package metadata.

## Risk
- Low
- No code changes, metadata only

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
