### PR TITLE
feat: add help --full option for comprehensive CLI documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ CI is implemented using GitHub Actions (`.github/workflows/ci.yaml`):
 2. Linting: Run `cargo clippy` and fix warnings
 3. Tests: Ensure `cargo test` passes
 4. Build: Ensure `cargo build` succeeds
+5. Full help: If CLI options changed, update `print_full_help()` in `src/main.rs`
 
 ## Commit message conventions
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,9 +12,21 @@ mod output;
 mod provider;
 mod trickery;
 
+const LONG_ABOUT: &str = "\
+Magic tool to generate things using LLM.
+
+Trickery is a CLI tool for generating textual artifacts using Large Language Models.
+It supports Jinja2-like template variables in prompts, model selection, and is
+designed for CI/CD integration.
+
+ENVIRONMENT VARIABLES:
+  OPENAI_API_KEY    Required. Your OpenAI API key for authentication.
+
+For comprehensive help with all options and examples, use: trickery help-full";
+
 /// Magic tool to generate things
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = LONG_ABOUT)]
 pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -40,6 +52,8 @@ pub enum Commands {
         #[arg(index = 1, value_enum)]
         shell: Shell,
     },
+    /// Print comprehensive help with all options and examples
+    HelpFull,
 }
 
 impl Cli {
@@ -88,8 +102,169 @@ async fn main() {
             eprintln!("Generating completion file for {shell}...");
             generate(*shell, &mut cmd, name, &mut io::stdout());
         }
+        Some(Commands::HelpFull) => {
+            print_full_help();
+        }
         None => {}
     }
+}
+
+fn print_full_help() {
+    print!(
+        r#"# trickery - CLI tool for generating textual artifacts using LLM
+
+## Overview
+
+Trickery is a command-line tool for generating content using Large Language Models.
+It supports Jinja2-like template variables in prompts, model selection, reasoning
+level configuration, and is designed for CI/CD integration.
+
+## Installation
+
+```bash
+cargo install trickery
+```
+
+## Environment Variables
+
+- `OPENAI_API_KEY` (required): Your OpenAI API key for authentication
+
+## Global Options
+
+- `-o, --output <FORMAT>`: Output format (json). When set, outputs structured JSON
+- `-h, --help`: Print help (use `--help` for detailed info)
+- `-V, --version`: Print version
+
+## Commands
+
+### generate - Generate content from prompts
+
+Generate text content from a prompt template file.
+
+**Options:**
+- `-i, --input <FILE>`: Path to the input prompt file (required)
+- `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
+- `-m, --model <MODEL>`: Model to use (e.g., gpt-5.2, gpt-5-mini, o1, o3-mini)
+- `-r, --reasoning <LEVEL>`: Reasoning level for o1/o3 models: low, medium, high
+- `--max-tokens <N>`: Maximum tokens in response
+- `--image <PATH|URL>`: Image files or URLs for multimodal prompts (can be repeated)
+- `--image-detail <LEVEL>`: Image detail level: auto, low, high (default: auto)
+
+**Examples:**
+
+```bash
+# Basic generation from a prompt file
+trickery generate -i prompts/greeting.md
+
+# With template variables
+trickery generate -i prompts/email.md --var name=John --var topic="Project Update"
+
+# Using a specific model
+trickery generate -i prompts/code.md -m gpt-5.2
+
+# With reasoning (for o1/o3 models)
+trickery generate -i prompts/analysis.md -m o3-mini -r high
+
+# JSON output for CI/CD
+trickery generate -i prompts/data.md -o json
+
+# Multimodal with image input
+trickery generate -i prompts/describe.md --image photo.jpg
+trickery generate -i prompts/compare.md --image img1.png --image img2.png
+```
+
+### image - Generate or edit images
+
+Generate new images or edit existing ones from a prompt template file.
+
+**Options:**
+- `-i, --input <FILE>`: Path to the input prompt file (required)
+- `-s, --save <FILE>`: Output file path (auto-generated if not provided)
+- `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
+- `-m, --model <MODEL>`: Model to use (e.g., gpt-4.1, gpt-5, gpt-5.2)
+- `--image <PATH|URL>`: Input image files or URLs for editing (can be repeated)
+- `--size <SIZE>`: Image size: auto, 1024x1024, 1024x1536 (portrait), 1536x1024 (landscape)
+- `--quality <QUALITY>`: Image quality: auto, low, medium, high
+- `--format <FORMAT>`: Output format: png, jpeg, webp
+- `--background <BG>`: Background: auto, transparent, opaque
+- `--action <ACTION>`: Action: auto, generate, edit
+- `--compression <0-100>`: Compression level for jpeg/webp formats
+
+**Examples:**
+
+```bash
+# Generate an image from a prompt
+trickery image -i prompts/logo.md
+
+# Save to specific file
+trickery image -i prompts/icon.md -s output/icon.png
+
+# With template variables
+trickery image -i prompts/banner.md --var title="Welcome" --var color=blue
+
+# High quality landscape image
+trickery image -i prompts/landscape.md --size 1536x1024 --quality high
+
+# Edit an existing image
+trickery image -i prompts/edit.md --image original.png --action edit
+
+# Transparent background (for logos/icons)
+trickery image -i prompts/logo.md --background transparent --format png
+
+# JSON output for CI/CD
+trickery image -i prompts/asset.md -o json
+```
+
+### completion - Generate shell completions
+
+Generate shell completion scripts for bash, zsh, fish, elvish, or powershell.
+
+**Usage:**
+```bash
+trickery completion <SHELL>
+```
+
+**Supported shells:** bash, zsh, fish, elvish, powershell
+
+**Examples:**
+
+```bash
+# Generate bash completions
+trickery completion bash > ~/.local/share/bash-completion/completions/trickery
+
+# Generate zsh completions
+trickery completion zsh > ~/.zfunc/_trickery
+
+# Generate fish completions
+trickery completion fish > ~/.config/fish/completions/trickery.fish
+```
+
+## Template Variables
+
+Prompt files support Jinja2-style template variables using `{{{{ variable }}}}` syntax.
+
+**Example prompt file (prompts/email.md):**
+```
+Write a professional email to {{{{ name }}}} about {{{{ topic }}}}.
+Keep it concise and friendly.
+```
+
+**Usage:**
+```bash
+trickery generate -i prompts/email.md --var name="Alice" --var topic="quarterly review"
+```
+
+## Exit Codes
+
+- `0`: Success
+- `1`: Error (missing file, API error, invalid arguments, etc.)
+
+## See Also
+
+- Project repository: https://github.com/chaliy/trickery
+- OpenAI API documentation: https://platform.openai.com/docs
+"#
+    );
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,69 @@ trickery generate -i prompts/email.md --var name="Alice" --var topic="quarterly 
     );
 }
 
-#[test]
-fn verify_cli() {
-    Cli::command().debug_assert();
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verify_cli() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn test_parse_help_command() {
+        let cli = Cli::try_parse_from(["trickery", "help"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Help { full: false })));
+    }
+
+    #[test]
+    fn test_parse_help_full_command() {
+        let cli = Cli::try_parse_from(["trickery", "help", "--full"]).unwrap();
+        assert!(matches!(cli.command, Some(Commands::Help { full: true })));
+    }
+
+    #[test]
+    fn test_long_about_mentions_help_full() {
+        assert!(LONG_ABOUT.contains("help --full"));
+    }
+
+    #[test]
+    fn test_full_help_contains_commands() {
+        // Capture full help by checking the static content
+        let help = r#"# trickery - CLI tool for generating textual artifacts using LLM"#;
+        assert!(help.contains("trickery"));
+
+        // Verify key sections exist in the full help output format
+        let sections = [
+            "## Overview",
+            "## Environment Variables",
+            "## Global Options",
+            "## Commands",
+            "### generate",
+            "### image",
+            "### completion",
+            "## Template Variables",
+            "## Exit Codes",
+        ];
+
+        // Get the full help content from the raw string in print_full_help
+        let full_help = include_str!("main.rs");
+        for section in sections {
+            assert!(
+                full_help.contains(section),
+                "Full help should contain section: {}",
+                section
+            );
+        }
+    }
+
+    #[test]
+    fn test_full_help_contains_examples() {
+        let full_help = include_str!("main.rs");
+        // Verify examples are present
+        assert!(full_help.contains("trickery generate -i"));
+        assert!(full_help.contains("trickery image -i"));
+        assert!(full_help.contains("trickery completion bash"));
+        assert!(full_help.contains("--var name="));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,11 +22,11 @@ designed for CI/CD integration.
 ENVIRONMENT VARIABLES:
   OPENAI_API_KEY    Required. Your OpenAI API key for authentication.
 
-For comprehensive help with all options and examples, use: trickery help-full";
+For comprehensive help with all options and examples, use: trickery help --full";
 
 /// Magic tool to generate things
 #[derive(Parser)]
-#[command(author, version, about, long_about = LONG_ABOUT)]
+#[command(author, version, about, long_about = LONG_ABOUT, disable_help_subcommand = true)]
 pub struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -52,8 +52,12 @@ pub enum Commands {
         #[arg(index = 1, value_enum)]
         shell: Shell,
     },
-    /// Print comprehensive help with all options and examples
-    HelpFull,
+    /// Print help information
+    Help {
+        /// Print comprehensive help with all options and examples
+        #[arg(long)]
+        full: bool,
+    },
 }
 
 impl Cli {
@@ -102,8 +106,12 @@ async fn main() {
             eprintln!("Generating completion file for {shell}...");
             generate(*shell, &mut cmd, name, &mut io::stdout());
         }
-        Some(Commands::HelpFull) => {
-            print_full_help();
+        Some(Commands::Help { full }) => {
+            if *full {
+                print_full_help();
+            } else {
+                Cli::command().print_help().unwrap();
+            }
         }
         None => {}
     }


### PR DESCRIPTION
## What
Add a `help --full` option that outputs comprehensive markdown-formatted help with all options and examples. This provides full knowledge about the tool for coding agents and automation.

## Why
Coding agents need complete CLI documentation to effectively use the tool. Standard `--help` is concise but lacks examples and detailed usage patterns. Having a `--full` flag provides machine-readable comprehensive docs without cluttering the default help.

## How
- Added `help` subcommand with `--full` flag
- `trickery help` shows standard help (same as `--help`)
- `trickery help --full` outputs full markdown documentation including:
  - All commands with complete option lists
  - Usage examples for each command
  - Template variable syntax
  - Environment variables
  - Exit codes
- Updated `--help` output to mention `trickery help --full`

## Usage
```bash
trickery --help          # Standard help, mentions help --full
trickery help            # Same as --help  
trickery help --full     # Full markdown documentation with examples
```

## Risk
Low
No breaking changes to existing functionality
Only adds new help subcommand

## Checklist
 Unit tests are passed
 Smoke tests are passed
 Documentation is updated