### PR TITLE
feat: add text input support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ High-level approach.
 Available specs:
 
 - `llm-provider.md` - LLM provider abstraction, OpenAI integration, design choices
+- `text-input.md` - Direct text input via --text option, alternative to file input
 
 Specification format: Abstract and Requirements sections.
 
@@ -135,6 +136,7 @@ Available test cases:
 - `image_multimodal.md` - Image input for multimodal prompts
 - `image_generate.md` - Image generation and editing command
 - `error_handling.md` - Error scenarios and messages
+- `text_input.md` - Direct text input via --text option
 
 ### Test case template
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Idea is simple, imagine you need to generate some docs using LLM as part of CI, 
 
 > [!TIP]
 > This README was generated with trickery
-> trickery generate -i ./prompts/trickery_readme.md > README.md
+> trickery generate ./prompts/trickery_readme.md > README.md
 
 
 ## Demo
@@ -28,7 +28,17 @@ trickery --help
 
 ```sh
 export OPENAI_API_KEY=s....d
-trickery generate -i ./prompts/trickery_readme.md > README.md
+trickery generate ./prompts/trickery_readme.md > README.md
+```
+
+### Using with OpenAI-compatible gateways
+
+You can use trickery with any OpenAI-compatible API gateway (like LiteLLM, Azure OpenAI, or local models) by setting the `OPENAI_BASE_URL` environment variable:
+
+```sh
+export OPENAI_API_KEY=your-key
+export OPENAI_BASE_URL=http://localhost:4000/v1
+trickery generate ./prompts/my_prompt.md
 ```
 
 Input file could be any text file, with Jinja2-like template variables, like `{{"{{app_version}}"}}`. To set this variables, please use `-v` flag, like `-v app_version=1.0.0`.

--- a/docs/image-generation.md
+++ b/docs/image-generation.md
@@ -4,9 +4,9 @@ Trickery supports generating and editing images using OpenAI's Responses API wit
 
 ## CLI Arguments
 
-### `--input <PATH>` / `-i <PATH>`
+### `[INPUT]` (positional) or `-i <INPUT>`
 
-Path to the prompt template file. Supports Jinja2-style `{{ variable }}` substitution.
+Input prompt: file path or direct text (auto-detected). Supports Jinja2-style `{{ variable }}` substitution when using a file.
 
 ### `--save <PATH>` / `-s <PATH>` (optional)
 
@@ -80,13 +80,13 @@ Template variables for prompt substitution.
 
 ```bash
 # Simple generation with explicit filename
-trickery image -i prompts/generate_diagram.md --save docs/images/colorful-architecture.png
+trickery image prompts/generate_diagram.md --save docs/images/colorful-architecture.png
 
 # Auto-generated filename (e.g., generate_diagram-a3f5x.png)
-trickery image -i prompts/generate_diagram.md
+trickery image prompts/generate_diagram.md
 
 # With quality settings
-trickery image -i prompts/generate_diagram.md -s architecture.png \
+trickery image prompts/generate_diagram.md -s architecture.png \
   --size 1536x1024 \
   --quality high
 ```
@@ -101,12 +101,12 @@ See [prompts/generate_diagram.md](../prompts/generate_diagram.md) for the prompt
 
 ```bash
 # Make an image look realistic
-trickery image -i prompts/make_realistic.md \
+trickery image prompts/make_realistic.md \
   --image test_data/example_images/image1.png \
   --save output.png
 
 # Edit with custom instruction
-trickery image -i prompts/edit_image.md \
+trickery image prompts/edit_image.md \
   --image test_data/example_images/image2.png \
   --save modified.png \
   -v instruction="make it green on pink"
@@ -117,7 +117,7 @@ See [prompts/make_realistic.md](../prompts/make_realistic.md) and [prompts/edit_
 ### Highlight Areas in Image
 
 ```bash
-trickery image -i prompts/highlight_humans.md \
+trickery image prompts/highlight_humans.md \
   --image test_data/example_images/image3.jpg \
   --save highlighted.png
 ```
@@ -127,7 +127,7 @@ See [prompts/highlight_humans.md](../prompts/highlight_humans.md) for the prompt
 ### With Template Variables
 
 ```bash
-trickery image -i prompts/generate_icon.md \
+trickery image prompts/generate_icon.md \
   --save icon.png \
   -v subject="rocket" \
   -v style="flat design"
@@ -139,7 +139,7 @@ See [prompts/generate_icon.md](../prompts/generate_icon.md) for the prompt templ
 
 ```bash
 # Combine elements from multiple images
-trickery image -i prompts/edit_image.md \
+trickery image prompts/edit_image.md \
   --image test_data/example_images/image1.png \
   --image test_data/example_images/image2.png \
   --save composite.png \
@@ -149,7 +149,7 @@ trickery image -i prompts/edit_image.md \
 ### Transparent Background
 
 ```bash
-trickery image -i prompts/generate_icon.md \
+trickery image prompts/generate_icon.md \
   --save logo.png \
   --background transparent \
   --format png \
@@ -160,7 +160,7 @@ trickery image -i prompts/generate_icon.md \
 ### JSON Output
 
 ```bash
-trickery image -i prompts/generate_diagram.md --save result.png -o json
+trickery image prompts/generate_diagram.md --save result.png -o json
 ```
 
 Output:

--- a/docs/input-images.md
+++ b/docs/input-images.md
@@ -34,7 +34,7 @@ Unknown extensions default to PNG MIME type.
 ### Single Local Image
 
 ```bash
-trickery generate -i prompts/describe_image.md --image test_data/example_images/image2.png
+trickery generate prompts/describe_image.md --image test_data/example_images/image2.png
 ```
 
 Where `prompts/describe_image.md` contains:
@@ -45,13 +45,13 @@ Describe what you see in this image in detail.
 ### Image from URL
 
 ```bash
-trickery generate -i prompts/describe_image.md --image https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
+trickery generate prompts/describe_image.md --image https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png
 ```
 
 ### Multiple Images
 
 ```bash
-trickery generate -i prompts/catalog_images.md \
+trickery generate prompts/catalog_images.md \
   --image test_data/example_images/image1.png \
   --image test_data/example_images/image2.png \
   --image test_data/example_images/image3.jpg
@@ -61,13 +61,13 @@ trickery generate -i prompts/catalog_images.md \
 
 ```bash
 # Low detail for quick classification
-trickery generate -i prompts/describe_image.md --image test_data/example_images/image1.png --image-detail low
+trickery generate prompts/describe_image.md --image test_data/example_images/image1.png --image-detail low
 ```
 
 ### Combined with Variables
 
 ```bash
-trickery generate -i prompts/review_ui.md \
+trickery generate prompts/review_ui.md \
   --image test_data/example_images/image2.png \
   --var focus="accessibility" \
   --var format="bullet points"
@@ -100,7 +100,7 @@ Image support requires a vision-capable model. Recommended models:
 
 Example with explicit model:
 ```bash
-trickery generate -i prompts/describe_image.md --image test_data/example_images/image1.png --model gpt-5.2
+trickery generate prompts/describe_image.md --image test_data/example_images/image1.png --model gpt-5.2
 ```
 
 ## Token Considerations

--- a/prompts/trickery_readme.md
+++ b/prompts/trickery_readme.md
@@ -19,7 +19,7 @@ Idea is simple, imagine you need to generate some docs using LLM as part of CI, 
 
 > [!TIP]
 > This README was generated with trickery
-> trickery generate -i ./prompts/trickery_readme.md > README.md
+> trickery generate ./prompts/trickery_readme.md > README.md
 
 
 ## Demo
@@ -39,7 +39,7 @@ trickery --help
 
 ```sh
 export OPENAI_API_KEY=s....d
-trickery generate -i ./prompts/trickery_readme.md > README.md
+trickery generate ./prompts/trickery_readme.md > README.md
 ```
 
 Input file could be any text file, with Jinja2-like template variables, like `{{"{{app_version}}"}}`. To set this variables, please use `-v` flag, like `-v app_version=1.0.0`.

--- a/specs/text-input.md
+++ b/specs/text-input.md
@@ -2,27 +2,43 @@
 
 ## Abstract
 
-Trickery's `--input` option supports both file paths and direct text, with auto-detection. If the provided value exists as a file, it reads from the file; otherwise, it treats the value as direct prompt text. This enables quick one-off generations without creating temporary files.
+Trickery's input supports both file paths and direct text, with auto-detection. If the provided value exists as a file, it reads from the file; otherwise, it treats the value as direct prompt text. Input can be provided as a positional argument or with the `-i` flag.
 
 ## Requirements
 
+### Input Methods
+
+Two equivalent ways to provide input:
+1. **Positional argument**: `trickery generate "prompt text"`
+2. **Named option**: `trickery generate -i "prompt text"`
+
+Both work identically. Positional is preferred for brevity.
+
 ### Input Auto-Detection
 
-The `-i, --input` option uses this logic:
+Once input is provided (either way), this logic applies:
 1. Check if the input value exists as a file on disk
 2. If file exists: read content from the file
 3. If file doesn't exist: use the input value directly as prompt text
 
 ### Behavior
 
-- File input: `trickery generate -i prompts/greeting.md` reads from file
-- Text input: `trickery generate -i "Write a haiku"` uses text directly
+```bash
+# File input (file exists, content read from file)
+trickery generate prompts/greeting.md
+trickery generate -i prompts/greeting.md
+
+# Text input (not a file, used as direct prompt)
+trickery generate "Write a haiku"
+trickery generate -i "Write a haiku"
+```
+
 - Template variables work with both: `--var name=Alice`
 - For `image` command, output filename defaults to `image-xxxxx.png` when input is text
 
 ### Long Text Support
 
-The `--input` option supports:
+Both positional and `-i` support:
 
 - Multi-line strings (using shell quoting)
 - Special characters and Unicode
@@ -34,12 +50,12 @@ Examples of passing long text:
 
 ```bash
 # Multi-line with shell quoting
-trickery generate -i "Line 1
+trickery generate "Line 1
 Line 2
 Line 3"
 
 # Using heredoc
-trickery generate -i "$(cat <<'EOF'
+trickery generate "$(cat <<'EOF'
 You are a helpful assistant.
 
 Please analyze the following:
@@ -47,21 +63,18 @@ Please analyze the following:
 - Point 2
 EOF
 )"
-
-# From pipe (when combined with xargs or similar)
-echo "Generate a poem" | xargs -I {} trickery generate -i "{}"
 ```
 
 ## Design Choices
 
+### Why support both positional and -i?
+
+1. Positional is more natural for quick one-liners
+2. `-i` flag maintains backwards compatibility
+3. `-i` is clearer when input looks like a flag (edge case)
+
 ### Why auto-detect instead of separate options?
 
-1. Simpler API: one option instead of two
+1. Simpler API: one input concept
 2. Intuitive behavior: file paths look like file paths, text looks like text
 3. No ambiguity in practice: prompts rarely look like existing file paths
-4. Matches common patterns in other CLI tools (e.g., `curl -d`)
-
-### Edge cases
-
-- If you have a file named "Hello world" and want to use it: the file will be read
-- If you want to use text that matches an existing filename: rename the file or use a path like `./filename`

--- a/specs/text-input.md
+++ b/specs/text-input.md
@@ -1,0 +1,75 @@
+# Text Input
+
+## Abstract
+
+Trickery supports direct text input via the `--text`/`-t` option as an alternative to reading prompts from files. This enables quick one-off generations without creating temporary files, supports long multi-line prompts, and integrates with shell scripting workflows.
+
+## Requirements
+
+### Input Options
+
+Both `generate` and `image` commands support two mutually exclusive input methods:
+
+1. **File input** (`-i, --input <FILE>`): Read prompt from a file
+2. **Text input** (`-t, --text <TEXT>`): Use text directly as the prompt
+
+### Validation Rules
+
+- Exactly one of `--input` or `--text` must be provided
+- If both are provided: error "Cannot specify both --input and --text"
+- If neither is provided: error "Either --input or --text is required"
+
+### Text Input Behavior
+
+- Text is used directly as the template content
+- Template variable substitution (`{{ var }}`) works with text input
+- For `image` command, output filename defaults to `image-xxxxx.png` when no input file
+
+### Long Text Support
+
+The `--text` option supports:
+
+- Multi-line strings (using shell quoting)
+- Special characters and Unicode
+- Very long prompts (limited only by shell argument length)
+
+### Shell Integration
+
+Examples of passing long text:
+
+```bash
+# Multi-line with shell quoting
+trickery generate -t "Line 1
+Line 2
+Line 3"
+
+# Using heredoc
+trickery generate -t "$(cat <<'EOF'
+You are a helpful assistant.
+
+Please analyze the following:
+- Point 1
+- Point 2
+EOF
+)"
+
+# From pipe (when combined with xargs or similar)
+echo "Generate a poem" | xargs -I {} trickery generate -t "{}"
+```
+
+## Design Choices
+
+### Why not stdin?
+
+Stdin support was considered but deferred because:
+1. Adds complexity for detecting interactive vs piped input
+2. Conflicts with potential future stdin use for binary data (images)
+3. Shell heredocs and `$()` provide adequate workarounds
+4. `--text` is explicit and predictable
+
+### Short flag `-t`
+
+The `-t` short flag was chosen because:
+- Mnemonic: "t" for "text"
+- Commonly used in other CLI tools
+- Does not conflict with existing flags

--- a/specs/text-input.md
+++ b/specs/text-input.md
@@ -2,17 +2,20 @@
 
 ## Abstract
 
-Trickery's input supports both file paths and direct text, with auto-detection. If the provided value exists as a file, it reads from the file; otherwise, it treats the value as direct prompt text. Input can be provided as a positional argument or with the `-i` flag.
+Trickery's input supports both file paths and direct text, with auto-detection. If the provided value exists as a file, it reads from the file; otherwise, it treats the value as direct prompt text. Input is typically provided as a positional argument.
 
 ## Requirements
 
 ### Input Methods
 
-Two equivalent ways to provide input:
-1. **Positional argument**: `trickery generate "prompt text"`
-2. **Named option**: `trickery generate -i "prompt text"`
+Input is provided as a positional argument:
 
-Both work identically. Positional is preferred for brevity.
+```bash
+trickery generate "prompt text"
+trickery generate prompts/greeting.md
+```
+
+The `-i` flag is also supported for backwards compatibility but positional is preferred.
 
 ### Input Auto-Detection
 
@@ -26,11 +29,9 @@ Once input is provided (either way), this logic applies:
 ```bash
 # File input (file exists, content read from file)
 trickery generate prompts/greeting.md
-trickery generate -i prompts/greeting.md
 
 # Text input (not a file, used as direct prompt)
 trickery generate "Write a haiku"
-trickery generate -i "Write a haiku"
 ```
 
 - Template variables work with both: `--var name=Alice`
@@ -38,7 +39,7 @@ trickery generate -i "Write a haiku"
 
 ### Long Text Support
 
-Both positional and `-i` support:
+Positional input supports:
 
 - Multi-line strings (using shell quoting)
 - Special characters and Unicode
@@ -67,11 +68,10 @@ EOF
 
 ## Design Choices
 
-### Why support both positional and -i?
+### Why keep -i as fallback?
 
-1. Positional is more natural for quick one-liners
-2. `-i` flag maintains backwards compatibility
-3. `-i` is clearer when input looks like a flag (edge case)
+1. Backwards compatibility with older scripts
+2. Useful when input looks like a flag (edge case)
 
 ### Why auto-detect instead of separate options?
 

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -31,13 +31,17 @@ fn parse_key_val(s: &str) -> Result<(String, Value), String> {
 }
 
 #[derive(Args)]
+#[command(
+    args_conflicts_with_subcommands = true,
+    override_usage = "trickery generate [INPUT] [OPTIONS]"
+)]
 pub struct GenerateArgs {
     /// Input prompt: file path or direct text (auto-detected)
-    #[arg(index = 1, value_hint = ValueHint::FilePath)]
+    #[arg(index = 1, value_name = "INPUT", value_hint = ValueHint::FilePath)]
     pub input_positional: Option<String>,
 
     /// Input prompt: file path or direct text (auto-detected)
-    #[arg(short, long = "input", value_hint = ValueHint::FilePath)]
+    #[arg(short, long = "input", value_name = "INPUT", value_hint = ValueHint::FilePath)]
     pub input_option: Option<String>,
 
     /// Variables to be used in prompt

--- a/src/commands/image.rs
+++ b/src/commands/image.rs
@@ -92,13 +92,14 @@ fn generate_output_filename(input: Option<&str>, format: Option<&ImageFormat>) -
 }
 
 #[derive(Args)]
+#[command(override_usage = "trickery image [INPUT] [OPTIONS]")]
 pub struct ImageArgs {
     /// Input prompt: file path or direct text (auto-detected)
-    #[arg(index = 1, value_hint = ValueHint::FilePath)]
+    #[arg(index = 1, value_name = "INPUT", value_hint = ValueHint::FilePath)]
     pub input_positional: Option<String>,
 
     /// Input prompt: file path or direct text (auto-detected)
-    #[arg(short, long = "input", value_hint = ValueHint::FilePath)]
+    #[arg(short, long = "input", value_name = "INPUT", value_hint = ValueHint::FilePath)]
     pub input_option: Option<String>,
 
     /// Output file path for the generated image (auto-generated if not provided)

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,11 +147,11 @@ cargo install trickery
 
 ### generate - Generate content from prompts
 
-Generate text content from a prompt template file or direct text input.
+Generate text content from a prompt. Input is auto-detected: if a file exists at
+the given path, it reads from the file; otherwise treats input as direct text.
 
 **Options:**
-- `-i, --input <FILE>`: Path to the input prompt file
-- `-t, --text <TEXT>`: Direct text input (alternative to --input file)
+- `-i, --input <INPUT>`: Prompt input - file path or direct text (auto-detected)
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-5.2, gpt-5-mini, o1, o3-mini)
 - `-r, --reasoning <LEVEL>`: Reasoning level for o1/o3 models: low, medium, high
@@ -159,51 +159,48 @@ Generate text content from a prompt template file or direct text input.
 - `--image <PATH|URL>`: Image files or URLs for multimodal prompts (can be repeated)
 - `--image-detail <LEVEL>`: Image detail level: auto, low, high (default: auto)
 
-Note: Either `--input` or `--text` is required, but not both.
-
 **Examples:**
 
 ```bash
-# Basic generation from a prompt file
+# From a prompt file (file exists, so reads from file)
 trickery generate -i prompts/greeting.md
 
-# Direct text input (no file needed)
-trickery generate -t "Write a haiku about programming"
+# Direct text input (not a file path, so uses as text)
+trickery generate -i "Write a haiku about programming"
 
 # Long text with shell quoting
-trickery generate -t "You are a helpful assistant.
+trickery generate -i "You are a helpful assistant.
 
 Explain the following concept in simple terms:
 What is machine learning and how does it work?"
 
-# With template variables (works with both -i and -t)
+# With template variables
 trickery generate -i prompts/email.md --var name=John --var topic="Project Update"
-trickery generate -t "Hello {{ name }}, welcome to {{ company }}!" --var name=Alice --var company=Acme
+trickery generate -i "Hello {{ name }}, welcome to {{ company }}!" --var name=Alice --var company=Acme
 
 # Using a specific model
 trickery generate -i prompts/code.md -m gpt-5.2
-trickery generate -t "Explain quantum computing" -m gpt-5.2
+trickery generate -i "Explain quantum computing" -m gpt-5.2
 
 # With reasoning (for o1/o3 models)
 trickery generate -i prompts/analysis.md -m o3-mini -r high
 
 # JSON output for CI/CD
 trickery generate -i prompts/data.md -o json
-trickery generate -t "Generate a JSON object with name and age fields" -o json
+trickery generate -i "Generate a JSON object with name and age fields" -o json
 
 # Multimodal with image input
 trickery generate -i prompts/describe.md --image photo.jpg
-trickery generate -t "What is in this image?" --image photo.jpg
-trickery generate -i prompts/compare.md --image img1.png --image img2.png
+trickery generate -i "What is in this image?" --image photo.jpg
 ```
 
 ### image - Generate or edit images
 
-Generate new images or edit existing ones from a prompt template file or direct text input.
+Generate new images or edit existing ones. Input is auto-detected: if a file exists
+at the given path, it reads from the file; otherwise treats input as direct text.
 
 **Options:**
-- `-i, --input <FILE>`: Path to the input prompt file
-- `-t, --text <TEXT>`: Direct text input (alternative to --input file)
+- `-i, --input <INPUT>`: Prompt input - file path or direct text (auto-detected)
 - `-s, --save <FILE>`: Output file path (auto-generated if not provided)
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-4.1, gpt-5, gpt-5.2)
@@ -215,45 +212,39 @@ Generate new images or edit existing ones from a prompt template file or direct 
 - `--action <ACTION>`: Action: auto, generate, edit
 - `--compression <0-100>`: Compression level for jpeg/webp formats
 
-Note: Either `--input` or `--text` is required, but not both.
-
 **Examples:**
 
 ```bash
-# Generate an image from a prompt file
+# From a prompt file
 trickery image -i prompts/logo.md
 
-# Direct text input (no file needed)
-trickery image -t "A cute cartoon cat sitting on a rainbow"
+# Direct text input
+trickery image -i "A cute cartoon cat sitting on a rainbow"
 
 # Long descriptive prompt
-trickery image -t "A professional logo for a tech startup called 'CloudSync'.
+trickery image -i "A professional logo for a tech startup called 'CloudSync'.
 Modern, minimalist design with blue and white colors.
 Should convey reliability and innovation."
 
 # Save to specific file
 trickery image -i prompts/icon.md -s output/icon.png
-trickery image -t "A simple house icon" -s icons/home.png
+trickery image -i "A simple house icon" -s icons/home.png
 
 # With template variables
 trickery image -i prompts/banner.md --var title="Welcome" --var color=blue
-trickery image -t "A {{ style }} banner with text: {{ title }}" --var style=modern --var title=Hello
+trickery image -i "A {{ style }} banner with text: {{ title }}" --var style=modern --var title=Hello
 
 # High quality landscape image
-trickery image -i prompts/landscape.md --size 1536x1024 --quality high
-trickery image -t "Beautiful mountain sunset" --size 1536x1024 --quality high
+trickery image -i "Beautiful mountain sunset" --size 1536x1024 --quality high
 
 # Edit an existing image
-trickery image -i prompts/edit.md --image original.png --action edit
-trickery image -t "Add a red hat to the person" --image photo.jpg --action edit
+trickery image -i "Add a red hat to the person" --image photo.jpg --action edit
 
 # Transparent background (for logos/icons)
-trickery image -i prompts/logo.md --background transparent --format png
-trickery image -t "Simple app icon" --background transparent --format png
+trickery image -i "Simple app icon" --background transparent --format png
 
 # JSON output for CI/CD
 trickery image -i prompts/asset.md -o json
-trickery image -t "Generate product thumbnail" -o json
 ```
 
 ### completion - Generate shell completions
@@ -375,49 +366,46 @@ mod tests {
     }
 
     #[test]
-    fn test_full_help_contains_text_option() {
+    fn test_full_help_contains_auto_detect() {
         let full_help = include_str!("main.rs");
-        // Verify --text option is documented
-        assert!(full_help.contains("-t, --text"));
-        assert!(full_help.contains("trickery generate -t"));
-        assert!(full_help.contains("trickery image -t"));
+        // Verify auto-detection is documented
+        assert!(full_help.contains("auto-detected"));
+        assert!(full_help.contains("file path or direct text"));
     }
 
     #[test]
-    fn test_parse_generate_with_text() {
-        let cli = Cli::try_parse_from(["trickery", "generate", "-t", "Hello world"]).unwrap();
-        if let Some(Commands::Generate(args)) = cli.command {
-            assert!(args.input.is_none());
-            assert_eq!(args.text, Some("Hello world".to_string()));
-        } else {
-            panic!("Expected Generate command");
-        }
-    }
-
-    #[test]
-    fn test_parse_generate_with_input() {
+    fn test_parse_generate_with_input_file() {
         let cli = Cli::try_parse_from(["trickery", "generate", "-i", "prompts/test.md"]).unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert!(args.input.is_some());
-            assert!(args.text.is_none());
+            assert_eq!(args.input, Some("prompts/test.md".to_string()));
         } else {
             panic!("Expected Generate command");
         }
     }
 
     #[test]
-    fn test_parse_generate_with_text_and_vars() {
+    fn test_parse_generate_with_input_text() {
+        let cli = Cli::try_parse_from(["trickery", "generate", "-i", "Hello world"]).unwrap();
+        if let Some(Commands::Generate(args)) = cli.command {
+            assert_eq!(args.input, Some("Hello world".to_string()));
+        } else {
+            panic!("Expected Generate command");
+        }
+    }
+
+    #[test]
+    fn test_parse_generate_with_input_and_vars() {
         let cli = Cli::try_parse_from([
             "trickery",
             "generate",
-            "-t",
+            "-i",
             "Hello {{ name }}",
             "--var",
             "name=Alice",
         ])
         .unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.text, Some("Hello {{ name }}".to_string()));
+            assert_eq!(args.input, Some("Hello {{ name }}".to_string()));
             assert_eq!(args.vars.len(), 1);
         } else {
             panic!("Expected Generate command");
@@ -425,23 +413,22 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_image_with_text() {
-        let cli = Cli::try_parse_from(["trickery", "image", "-t", "A red circle"]).unwrap();
+    fn test_parse_image_with_input_text() {
+        let cli = Cli::try_parse_from(["trickery", "image", "-i", "A red circle"]).unwrap();
         if let Some(Commands::Image(args)) = cli.command {
-            assert!(args.input.is_none());
-            assert_eq!(args.text, Some("A red circle".to_string()));
+            assert_eq!(args.input, Some("A red circle".to_string()));
         } else {
             panic!("Expected Image command");
         }
     }
 
     #[test]
-    fn test_parse_image_with_text_and_save() {
+    fn test_parse_image_with_input_and_save() {
         let cli =
-            Cli::try_parse_from(["trickery", "image", "-t", "Blue square", "-s", "output.png"])
+            Cli::try_parse_from(["trickery", "image", "-i", "Blue square", "-s", "output.png"])
                 .unwrap();
         if let Some(Commands::Image(args)) = cli.command {
-            assert_eq!(args.text, Some("Blue square".to_string()));
+            assert_eq!(args.input, Some("Blue square".to_string()));
             assert!(args.save.is_some());
         } else {
             panic!("Expected Image command");
@@ -449,11 +436,11 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_generate_with_long_text() {
+    fn test_parse_generate_with_long_input() {
         let long_text = "This is a very long prompt.\n\nIt has multiple lines.\n\nAnd lots of content that should be handled correctly by the CLI parser.";
-        let cli = Cli::try_parse_from(["trickery", "generate", "-t", long_text]).unwrap();
+        let cli = Cli::try_parse_from(["trickery", "generate", "-i", long_text]).unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.text, Some(long_text.to_string()));
+            assert_eq!(args.input, Some(long_text.to_string()));
         } else {
             panic!("Expected Generate command");
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,13 +152,12 @@ the given path, it reads from the file; otherwise treats input as direct text.
 
 **Usage:**
 ```bash
-trickery generate [INPUT]           # positional argument
-trickery generate -i <INPUT>        # or use -i flag
+trickery generate [INPUT] [OPTIONS]
 ```
 
 **Options:**
-- `<INPUT>`: Prompt input as positional arg - file path or direct text (auto-detected)
-- `-i, --input <INPUT>`: Same as positional, alternative syntax
+- `[INPUT]`: Prompt input - file path or direct text (auto-detected)
+- `-i, --input <INPUT>`: Alternative to positional (for backwards compatibility)
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-5.2, gpt-5-mini, o1, o3-mini)
 - `-r, --reasoning <LEVEL>`: Reasoning level for o1/o3 models: low, medium, high
@@ -169,17 +168,11 @@ trickery generate -i <INPUT>        # or use -i flag
 **Examples:**
 
 ```bash
-# From a prompt file (positional)
+# From a prompt file
 trickery generate prompts/greeting.md
 
-# From a prompt file (with -i flag)
-trickery generate -i prompts/greeting.md
-
-# Direct text input (positional)
+# Direct text input
 trickery generate "Write a haiku about programming"
-
-# Direct text input (with -i flag)
-trickery generate -i "Write a haiku about programming"
 
 # Long text with shell quoting
 trickery generate "You are a helpful assistant.
@@ -211,13 +204,12 @@ at the given path, it reads from the file; otherwise treats input as direct text
 
 **Usage:**
 ```bash
-trickery image [INPUT]           # positional argument
-trickery image -i <INPUT>        # or use -i flag
+trickery image [INPUT] [OPTIONS]
 ```
 
 **Options:**
-- `<INPUT>`: Prompt input as positional arg - file path or direct text (auto-detected)
-- `-i, --input <INPUT>`: Same as positional, alternative syntax
+- `[INPUT]`: Prompt input - file path or direct text (auto-detected)
+- `-i, --input <INPUT>`: Alternative to positional (for backwards compatibility)
 - `-s, --save <FILE>`: Output file path (auto-generated if not provided)
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-4.1, gpt-5, gpt-5.2)
@@ -232,14 +224,11 @@ trickery image -i <INPUT>        # or use -i flag
 **Examples:**
 
 ```bash
-# From a prompt file (positional)
+# From a prompt file
 trickery image prompts/logo.md
 
-# Direct text input (positional)
+# Direct text input
 trickery image "A cute cartoon cat sitting on a rainbow"
-
-# With -i flag
-trickery image -i prompts/logo.md
 
 # Long descriptive prompt
 trickery image "A professional logo for a tech startup called 'CloudSync'.
@@ -300,7 +289,7 @@ Keep it concise and friendly.
 
 **Usage:**
 ```bash
-trickery generate -i prompts/email.md --var name="Alice" --var topic="quarterly review"
+trickery generate prompts/email.md --var name="Alice" --var topic="quarterly review"
 ```
 
 ## Exit Codes
@@ -376,8 +365,8 @@ mod tests {
     fn test_full_help_contains_examples() {
         let full_help = include_str!("main.rs");
         // Verify examples are present
-        assert!(full_help.contains("trickery generate -i"));
-        assert!(full_help.contains("trickery image -i"));
+        assert!(full_help.contains("trickery generate prompts/"));
+        assert!(full_help.contains("trickery image prompts/"));
         assert!(full_help.contains("trickery completion bash"));
         assert!(full_help.contains("--var name="));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,8 +150,15 @@ cargo install trickery
 Generate text content from a prompt. Input is auto-detected: if a file exists at
 the given path, it reads from the file; otherwise treats input as direct text.
 
+**Usage:**
+```bash
+trickery generate [INPUT]           # positional argument
+trickery generate -i <INPUT>        # or use -i flag
+```
+
 **Options:**
-- `-i, --input <INPUT>`: Prompt input - file path or direct text (auto-detected)
+- `<INPUT>`: Prompt input as positional arg - file path or direct text (auto-detected)
+- `-i, --input <INPUT>`: Same as positional, alternative syntax
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-5.2, gpt-5-mini, o1, o3-mini)
 - `-r, --reasoning <LEVEL>`: Reasoning level for o1/o3 models: low, medium, high
@@ -162,36 +169,39 @@ the given path, it reads from the file; otherwise treats input as direct text.
 **Examples:**
 
 ```bash
-# From a prompt file (file exists, so reads from file)
+# From a prompt file (positional)
+trickery generate prompts/greeting.md
+
+# From a prompt file (with -i flag)
 trickery generate -i prompts/greeting.md
 
-# Direct text input (not a file path, so uses as text)
+# Direct text input (positional)
+trickery generate "Write a haiku about programming"
+
+# Direct text input (with -i flag)
 trickery generate -i "Write a haiku about programming"
 
 # Long text with shell quoting
-trickery generate -i "You are a helpful assistant.
+trickery generate "You are a helpful assistant.
 
 Explain the following concept in simple terms:
 What is machine learning and how does it work?"
 
 # With template variables
-trickery generate -i prompts/email.md --var name=John --var topic="Project Update"
-trickery generate -i "Hello {{ name }}, welcome to {{ company }}!" --var name=Alice --var company=Acme
+trickery generate prompts/email.md --var name=John --var topic="Project Update"
+trickery generate "Hello {{ name }}!" --var name=Alice
 
 # Using a specific model
-trickery generate -i prompts/code.md -m gpt-5.2
-trickery generate -i "Explain quantum computing" -m gpt-5.2
+trickery generate "Explain quantum computing" -m gpt-5.2
 
 # With reasoning (for o1/o3 models)
-trickery generate -i prompts/analysis.md -m o3-mini -r high
+trickery generate prompts/analysis.md -m o3-mini -r high
 
 # JSON output for CI/CD
-trickery generate -i prompts/data.md -o json
-trickery generate -i "Generate a JSON object with name and age fields" -o json
+trickery generate "Generate a JSON object" -o json
 
 # Multimodal with image input
-trickery generate -i prompts/describe.md --image photo.jpg
-trickery generate -i "What is in this image?" --image photo.jpg
+trickery generate "What is in this image?" --image photo.jpg
 ```
 
 ### image - Generate or edit images
@@ -199,8 +209,15 @@ trickery generate -i "What is in this image?" --image photo.jpg
 Generate new images or edit existing ones. Input is auto-detected: if a file exists
 at the given path, it reads from the file; otherwise treats input as direct text.
 
+**Usage:**
+```bash
+trickery image [INPUT]           # positional argument
+trickery image -i <INPUT>        # or use -i flag
+```
+
 **Options:**
-- `-i, --input <INPUT>`: Prompt input - file path or direct text (auto-detected)
+- `<INPUT>`: Prompt input as positional arg - file path or direct text (auto-detected)
+- `-i, --input <INPUT>`: Same as positional, alternative syntax
 - `-s, --save <FILE>`: Output file path (auto-generated if not provided)
 - `-v, --var <KEY=VALUE>`: Variables to be used in prompt (can be repeated)
 - `-m, --model <MODEL>`: Model to use (e.g., gpt-4.1, gpt-5, gpt-5.2)
@@ -215,36 +232,36 @@ at the given path, it reads from the file; otherwise treats input as direct text
 **Examples:**
 
 ```bash
-# From a prompt file
+# From a prompt file (positional)
+trickery image prompts/logo.md
+
+# Direct text input (positional)
+trickery image "A cute cartoon cat sitting on a rainbow"
+
+# With -i flag
 trickery image -i prompts/logo.md
 
-# Direct text input
-trickery image -i "A cute cartoon cat sitting on a rainbow"
-
 # Long descriptive prompt
-trickery image -i "A professional logo for a tech startup called 'CloudSync'.
-Modern, minimalist design with blue and white colors.
-Should convey reliability and innovation."
+trickery image "A professional logo for a tech startup called 'CloudSync'.
+Modern, minimalist design with blue and white colors."
 
 # Save to specific file
-trickery image -i prompts/icon.md -s output/icon.png
-trickery image -i "A simple house icon" -s icons/home.png
+trickery image "A simple house icon" -s icons/home.png
 
 # With template variables
-trickery image -i prompts/banner.md --var title="Welcome" --var color=blue
-trickery image -i "A {{ style }} banner with text: {{ title }}" --var style=modern --var title=Hello
+trickery image "A {{ style }} banner" --var style=modern
 
 # High quality landscape image
-trickery image -i "Beautiful mountain sunset" --size 1536x1024 --quality high
+trickery image "Beautiful mountain sunset" --size 1536x1024 --quality high
 
 # Edit an existing image
-trickery image -i "Add a red hat to the person" --image photo.jpg --action edit
+trickery image "Add a red hat to the person" --image photo.jpg --action edit
 
 # Transparent background (for logos/icons)
-trickery image -i "Simple app icon" --background transparent --format png
+trickery image "Simple app icon" --background transparent --format png
 
 # JSON output for CI/CD
-trickery image -i prompts/asset.md -o json
+trickery image prompts/asset.md -o json
 ```
 
 ### completion - Generate shell completions
@@ -374,38 +391,55 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_generate_with_input_file() {
+    fn test_full_help_contains_positional() {
+        let full_help = include_str!("main.rs");
+        // Verify positional argument is documented
+        assert!(full_help.contains("positional"));
+        assert!(full_help.contains("[INPUT]"));
+    }
+
+    #[test]
+    fn test_parse_generate_with_input_flag() {
         let cli = Cli::try_parse_from(["trickery", "generate", "-i", "prompts/test.md"]).unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.input, Some("prompts/test.md".to_string()));
+            assert_eq!(args.get_input(), Some(&"prompts/test.md".to_string()));
         } else {
             panic!("Expected Generate command");
         }
     }
 
     #[test]
-    fn test_parse_generate_with_input_text() {
-        let cli = Cli::try_parse_from(["trickery", "generate", "-i", "Hello world"]).unwrap();
+    fn test_parse_generate_with_positional() {
+        let cli = Cli::try_parse_from(["trickery", "generate", "prompts/test.md"]).unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.input, Some("Hello world".to_string()));
+            assert_eq!(args.get_input(), Some(&"prompts/test.md".to_string()));
         } else {
             panic!("Expected Generate command");
         }
     }
 
     #[test]
-    fn test_parse_generate_with_input_and_vars() {
+    fn test_parse_generate_positional_text() {
+        let cli = Cli::try_parse_from(["trickery", "generate", "Hello world"]).unwrap();
+        if let Some(Commands::Generate(args)) = cli.command {
+            assert_eq!(args.get_input(), Some(&"Hello world".to_string()));
+        } else {
+            panic!("Expected Generate command");
+        }
+    }
+
+    #[test]
+    fn test_parse_generate_positional_with_vars() {
         let cli = Cli::try_parse_from([
             "trickery",
             "generate",
-            "-i",
             "Hello {{ name }}",
             "--var",
             "name=Alice",
         ])
         .unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.input, Some("Hello {{ name }}".to_string()));
+            assert_eq!(args.get_input(), Some(&"Hello {{ name }}".to_string()));
             assert_eq!(args.vars.len(), 1);
         } else {
             panic!("Expected Generate command");
@@ -413,22 +447,31 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_image_with_input_text() {
+    fn test_parse_image_with_input_flag() {
         let cli = Cli::try_parse_from(["trickery", "image", "-i", "A red circle"]).unwrap();
         if let Some(Commands::Image(args)) = cli.command {
-            assert_eq!(args.input, Some("A red circle".to_string()));
+            assert_eq!(args.get_input(), Some(&"A red circle".to_string()));
         } else {
             panic!("Expected Image command");
         }
     }
 
     #[test]
-    fn test_parse_image_with_input_and_save() {
-        let cli =
-            Cli::try_parse_from(["trickery", "image", "-i", "Blue square", "-s", "output.png"])
-                .unwrap();
+    fn test_parse_image_with_positional() {
+        let cli = Cli::try_parse_from(["trickery", "image", "A red circle"]).unwrap();
         if let Some(Commands::Image(args)) = cli.command {
-            assert_eq!(args.input, Some("Blue square".to_string()));
+            assert_eq!(args.get_input(), Some(&"A red circle".to_string()));
+        } else {
+            panic!("Expected Image command");
+        }
+    }
+
+    #[test]
+    fn test_parse_image_positional_with_save() {
+        let cli =
+            Cli::try_parse_from(["trickery", "image", "Blue square", "-s", "output.png"]).unwrap();
+        if let Some(Commands::Image(args)) = cli.command {
+            assert_eq!(args.get_input(), Some(&"Blue square".to_string()));
             assert!(args.save.is_some());
         } else {
             panic!("Expected Image command");
@@ -436,11 +479,11 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_generate_with_long_input() {
+    fn test_parse_generate_positional_long_text() {
         let long_text = "This is a very long prompt.\n\nIt has multiple lines.\n\nAnd lots of content that should be handled correctly by the CLI parser.";
-        let cli = Cli::try_parse_from(["trickery", "generate", "-i", long_text]).unwrap();
+        let cli = Cli::try_parse_from(["trickery", "generate", long_text]).unwrap();
         if let Some(Commands::Generate(args)) = cli.command {
-            assert_eq!(args.input, Some(long_text.to_string()));
+            assert_eq!(args.get_input(), Some(&long_text.to_string()));
         } else {
             panic!("Expected Generate command");
         }

--- a/test_cases/basic_generation.md
+++ b/test_cases/basic_generation.md
@@ -10,13 +10,13 @@ Validates that trickery can generate output from a simple prompt file without va
 ## Steps
 
 ### 1. Generate from simple prompt
-**Run:** `trickery generate -i prompts/dad_jokes.md`
+**Run:** `trickery generate prompts/dad_jokes.md`
 **Expect:** LLM response printed to stdout (a dad joke)
 
 ### 2. Generate with model selection
-**Run:** `trickery generate -i prompts/dad_jokes.md -m gpt-4o-mini`
+**Run:** `trickery generate prompts/dad_jokes.md -m gpt-4o-mini`
 **Expect:** LLM response from specified model
 
 ### 3. Generate with max tokens limit
-**Run:** `trickery generate -i prompts/dad_jokes.md --max-tokens 50`
+**Run:** `trickery generate prompts/dad_jokes.md --max-tokens 50`
 **Expect:** Response truncated to approximately 50 tokens

--- a/test_cases/error_handling.md
+++ b/test_cases/error_handling.md
@@ -8,22 +8,18 @@ Validates proper error messages for invalid inputs and missing requirements.
 
 ## Steps
 
-### 1. Missing input file
+### 1. Missing input
 **Run:** `trickery generate`
-**Expect:** Error: "Input file path is required"
+**Expect:** Error: "Input is required"
 
-### 2. Non-existent file
-**Run:** `trickery generate -i nonexistent.md`
-**Expect:** Error: "Failed to read input file 'nonexistent.md': No such file"
-
-### 3. Missing API key
-**Run:** `unset OPENAI_API_KEY && trickery generate -i prompts/dad_jokes.md`
+### 2. Missing API key
+**Run:** `unset OPENAI_API_KEY && trickery generate prompts/dad_jokes.md`
 **Expect:** Error indicating missing or invalid API key
 
-### 4. Invalid variable format
-**Run:** `trickery generate -i prompts/dad_jokes.md --var invalidformat`
+### 3. Invalid variable format
+**Run:** `trickery generate prompts/dad_jokes.md --var invalidformat`
 **Expect:** Error: "invalid KEY=VALUE: no `=` found"
 
-### 5. Invalid reasoning level
-**Run:** `trickery generate -i prompts/dad_jokes.md -r invalid`
+### 4. Invalid reasoning level
+**Run:** `trickery generate prompts/dad_jokes.md -r invalid`
 **Expect:** Error about invalid reasoning level value

--- a/test_cases/image_generate.md
+++ b/test_cases/image_generate.md
@@ -11,45 +11,45 @@ Validates the `image` command for generating and editing images using OpenAI's R
 ## Steps
 
 ### 1. Generate image from prompt
-**Run:** `trickery image -i prompts/generate_diagram.md --save /tmp/diagram.png`
+**Run:** `trickery image prompts/generate_diagram.md --save /tmp/diagram.png`
 **Expect:** Image saved to `/tmp/diagram.png`, success message printed
 
 ### 2. Generate with size option
-**Run:** `trickery image -i prompts/generate_diagram.md --save /tmp/diagram.png --size 1536x1024`
+**Run:** `trickery image prompts/generate_diagram.md --save /tmp/diagram.png --size 1536x1024`
 **Expect:** Landscape image (1536x1024) saved to output path
 
 ### 3. Generate with quality option
-**Run:** `trickery image -i prompts/generate_diagram.md --save /tmp/diagram.png --quality high`
+**Run:** `trickery image prompts/generate_diagram.md --save /tmp/diagram.png --quality high`
 **Expect:** High quality image generated (higher cost, better detail)
 
 ### 4. Generate with template variables
-**Run:** `trickery image -i prompts/generate_icon.md --save /tmp/icon.png -v subject=rocket -v style="flat design"`
+**Run:** `trickery image prompts/generate_icon.md --save /tmp/icon.png -v subject=rocket -v style="flat design"`
 **Expect:** Icon generated based on substituted prompt variables
 
 ### 5. Edit existing image
-**Run:** `trickery image -i prompts/edit_image.md --image test_data/example_images/image1.png --save /tmp/edited.png -v instruction="make it green on pink"`
+**Run:** `trickery image prompts/edit_image.md --image test_data/example_images/image1.png --save /tmp/edited.png -v instruction="make it green on pink"`
 **Expect:** Modified image saved with the requested edit applied
 
 ### 6. Transparent background
-**Run:** `trickery image -i prompts/generate_icon.md --save /tmp/logo.png --background transparent --format png -v subject=star -v style=simple`
+**Run:** `trickery image prompts/generate_icon.md --save /tmp/logo.png --background transparent --format png -v subject=star -v style=simple`
 **Expect:** PNG image with transparent background
 
 ### 7. JSON output format
-**Run:** `trickery image -i prompts/generate_diagram.md --save /tmp/test.png -o json`
+**Run:** `trickery image prompts/generate_diagram.md --save /tmp/test.png -o json`
 **Expect:** JSON output with `output_path` and `revised_prompt` fields
 
 ### 8. Multiple input images
-**Run:** `trickery image -i prompts/edit_image.md --image test_data/example_images/image1.png --image test_data/example_images/image2.png --save /tmp/composite.png -v instruction="combine these images"`
+**Run:** `trickery image prompts/edit_image.md --image test_data/example_images/image1.png --image test_data/example_images/image2.png --save /tmp/composite.png -v instruction="combine these images"`
 **Expect:** Image generated using both input images as context
 
 ### 9. Auto-generated filename
-**Run:** `trickery image -i prompts/generate_diagram.md`
+**Run:** `trickery image prompts/generate_diagram.md`
 **Expect:** Image saved to auto-generated filename (e.g., `generate_diagram-a3f5x.png` in current directory), success message shows path
 
 ### 10. Short flag for save
-**Run:** `trickery image -i prompts/generate_diagram.md -s /tmp/short.png`
+**Run:** `trickery image prompts/generate_diagram.md -s /tmp/short.png`
 **Expect:** Image saved to `/tmp/short.png` using short `-s` flag
 
 ### 11. Highlight humans in image
-**Run:** `trickery image -i prompts/highlight_humans.md --image test_data/example_images/image3.jpg --save /tmp/highlighted.png`
+**Run:** `trickery image prompts/highlight_humans.md --image test_data/example_images/image3.jpg --save /tmp/highlighted.png`
 **Expect:** Image with red circles around humans and numbered labels

--- a/test_cases/image_multimodal.md
+++ b/test_cases/image_multimodal.md
@@ -12,17 +12,17 @@ Validates multimodal image input for vision-capable prompts.
 ## Steps
 
 ### 1. Image from local file
-**Run:** `trickery generate -i prompts/describe_image.md --image ./test.png`
+**Run:** `trickery generate prompts/describe_image.md --image ./test.png`
 **Expect:** LLM describes contents of the image
 
 ### 2. Image from URL
-**Run:** `trickery generate -i prompts/describe_image.md --image "https://example.com/image.jpg"`
+**Run:** `trickery generate prompts/describe_image.md --image "https://example.com/image.jpg"`
 **Expect:** LLM fetches and describes the remote image
 
 ### 3. Image detail level
-**Run:** `trickery generate -i prompts/describe_image.md --image ./test.png --image-detail high`
+**Run:** `trickery generate prompts/describe_image.md --image ./test.png --image-detail high`
 **Expect:** Higher detail analysis; may take longer and use more tokens
 
 ### 4. Multiple images
-**Run:** `trickery generate -i prompts/catalog_images.md --image ./img1.png --image ./img2.png`
+**Run:** `trickery generate prompts/catalog_images.md --image ./img1.png --image ./img2.png`
 **Expect:** LLM processes and references both images in response

--- a/test_cases/json_output.md
+++ b/test_cases/json_output.md
@@ -11,13 +11,13 @@ Validates the `-o json` flag produces structured JSON output.
 ## Steps
 
 ### 1. JSON output format
-**Run:** `trickery -o json generate -i prompts/dad_jokes.md`
+**Run:** `trickery -o json generate prompts/dad_jokes.md`
 **Expect:** Output is valid JSON with structure: `{"output": "<response>"}`
 
 ### 2. JSON output piped to jq
-**Run:** `trickery -o json generate -i prompts/dad_jokes.md | jq .output`
+**Run:** `trickery -o json generate prompts/dad_jokes.md | jq .output`
 **Expect:** Extracted output string without JSON wrapper
 
 ### 3. Compare interactive vs JSON mode
-**Run:** `trickery generate -i prompts/dad_jokes.md` vs `trickery -o json generate -i prompts/dad_jokes.md`
+**Run:** `trickery generate prompts/dad_jokes.md` vs `trickery -o json generate prompts/dad_jokes.md`
 **Expect:** Interactive mode prints raw text; JSON mode wraps in object

--- a/test_cases/template_variables.md
+++ b/test_cases/template_variables.md
@@ -11,13 +11,13 @@ Validates Jinja2-style variable substitution in prompt templates.
 ## Steps
 
 ### 1. Single variable substitution
-**Run:** `trickery generate -i /tmp/test_vars.md --var name=Alice`
+**Run:** `trickery generate /tmp/test_vars.md --var name=Alice`
 **Expect:** Prompt renders with "Alice" replacing `{{ name }}`; `{{ role }}` may appear literally or cause template warning
 
 ### 2. Multiple variables
-**Run:** `trickery generate -i /tmp/test_vars.md --var name=Bob --var role=developer`
+**Run:** `trickery generate /tmp/test_vars.md --var name=Bob --var role=developer`
 **Expect:** Both variables substituted; response references "Bob" and "developer"
 
 ### 3. Variable with special characters
-**Run:** `trickery generate -i /tmp/test_vars.md --var name="John Doe" --var role="senior engineer"`
+**Run:** `trickery generate /tmp/test_vars.md --var name="John Doe" --var role="senior engineer"`
 **Expect:** Values with spaces handled correctly

--- a/test_cases/text_input.md
+++ b/test_cases/text_input.md
@@ -1,7 +1,7 @@
-# Test: Text Input
+# Test: Text Input (Auto-Detection)
 
 ## Abstract
-Validates direct text input via --text/-t option for generate and image commands.
+Validates that --input auto-detects file paths vs direct text input.
 
 ## Prerequisites
 - `OPENAI_API_KEY` environment variable set
@@ -9,18 +9,22 @@ Validates direct text input via --text/-t option for generate and image commands
 
 ## Steps
 
-### 1. Basic text input (generate)
-**Run:** `trickery generate -t "Tell me a short joke"`
-**Expect:** LLM response with a joke
+### 1. Text input (generate)
+**Run:** `trickery generate -i "Tell me a short joke"`
+**Expect:** LLM response with a joke (input treated as text since no such file exists)
 
-### 2. Basic text input (image)
-**Run:** `trickery image -t "A simple red circle on white background" -s /tmp/test_circle.png`
+### 2. File input (generate)
+**Run:** `trickery generate -i prompts/dad_jokes.md`
+**Expect:** LLM response based on file content (file exists, so reads from it)
+
+### 3. Text input (image)
+**Run:** `trickery image -i "A simple red circle on white background" -s /tmp/test_circle.png`
 **Expect:** Image saved to /tmp/test_circle.png
 
-### 3. Multi-line text input
+### 4. Multi-line text input
 **Run:**
 ```bash
-trickery generate -t "You are a poet.
+trickery generate -i "You are a poet.
 
 Write a haiku about:
 - The moon
@@ -28,14 +32,14 @@ Write a haiku about:
 ```
 **Expect:** Haiku response
 
-### 4. Text with template variables
-**Run:** `trickery generate -t "Hello {{ name }}, you work at {{ company }}." --var name=Alice --var company=Acme`
+### 5. Text with template variables
+**Run:** `trickery generate -i "Hello {{ name }}, you work at {{ company }}." --var name=Alice --var company=Acme`
 **Expect:** Response references "Alice" and "Acme"
 
-### 5. Long text input
+### 6. Long text input
 **Run:**
 ```bash
-trickery generate -t "$(cat <<'EOF'
+trickery generate -i "$(cat <<'EOF'
 You are a technical writer. Please summarize the following:
 
 1. Rust is a systems programming language focused on safety.
@@ -50,22 +54,18 @@ EOF
 ```
 **Expect:** 2-sentence summary of Rust features
 
-### 6. Error: both --input and --text
-**Run:** `trickery generate -i prompts/dad_jokes.md -t "Hello"`
-**Expect:** Error: "Cannot specify both --input and --text"
-
-### 7. Error: neither --input nor --text
+### 7. Error: missing --input
 **Run:** `trickery generate`
-**Expect:** Error: "Either --input or --text is required"
+**Expect:** Error about missing --input
 
 ### 8. Image with text and auto-generated filename
-**Run:** `trickery image -t "Blue square"`
-**Expect:** Image saved to image-xxxxx.png (auto-generated filename)
+**Run:** `trickery image -i "Blue square"`
+**Expect:** Image saved to image-xxxxx.png (auto-generated filename, not based on input text)
 
 ### 9. Text input with JSON output
-**Run:** `trickery generate -t "Say hello" -o json`
+**Run:** `trickery generate -i "Say hello" -o json`
 **Expect:** JSON output with "output" field
 
 ### 10. Text input with model selection
-**Run:** `trickery generate -t "Count to 5" -m gpt-4o-mini`
+**Run:** `trickery generate -i "Count to 5" -m gpt-4o-mini`
 **Expect:** Response with numbers 1-5

--- a/test_cases/text_input.md
+++ b/test_cases/text_input.md
@@ -1,0 +1,71 @@
+# Test: Text Input
+
+## Abstract
+Validates direct text input via --text/-t option for generate and image commands.
+
+## Prerequisites
+- `OPENAI_API_KEY` environment variable set
+- `cargo install --path .`
+
+## Steps
+
+### 1. Basic text input (generate)
+**Run:** `trickery generate -t "Tell me a short joke"`
+**Expect:** LLM response with a joke
+
+### 2. Basic text input (image)
+**Run:** `trickery image -t "A simple red circle on white background" -s /tmp/test_circle.png`
+**Expect:** Image saved to /tmp/test_circle.png
+
+### 3. Multi-line text input
+**Run:**
+```bash
+trickery generate -t "You are a poet.
+
+Write a haiku about:
+- The moon
+- Silence"
+```
+**Expect:** Haiku response
+
+### 4. Text with template variables
+**Run:** `trickery generate -t "Hello {{ name }}, you work at {{ company }}." --var name=Alice --var company=Acme`
+**Expect:** Response references "Alice" and "Acme"
+
+### 5. Long text input
+**Run:**
+```bash
+trickery generate -t "$(cat <<'EOF'
+You are a technical writer. Please summarize the following:
+
+1. Rust is a systems programming language focused on safety.
+2. It prevents null pointer exceptions through its ownership system.
+3. The borrow checker ensures memory safety at compile time.
+4. Cargo is the package manager and build system.
+5. Crates are Rust packages published to crates.io.
+
+Provide a 2-sentence summary.
+EOF
+)"
+```
+**Expect:** 2-sentence summary of Rust features
+
+### 6. Error: both --input and --text
+**Run:** `trickery generate -i prompts/dad_jokes.md -t "Hello"`
+**Expect:** Error: "Cannot specify both --input and --text"
+
+### 7. Error: neither --input nor --text
+**Run:** `trickery generate`
+**Expect:** Error: "Either --input or --text is required"
+
+### 8. Image with text and auto-generated filename
+**Run:** `trickery image -t "Blue square"`
+**Expect:** Image saved to image-xxxxx.png (auto-generated filename)
+
+### 9. Text input with JSON output
+**Run:** `trickery generate -t "Say hello" -o json`
+**Expect:** JSON output with "output" field
+
+### 10. Text input with model selection
+**Run:** `trickery generate -t "Count to 5" -m gpt-4o-mini`
+**Expect:** Response with numbers 1-5

--- a/test_cases/text_input.md
+++ b/test_cases/text_input.md
@@ -1,7 +1,7 @@
-# Test: Text Input (Auto-Detection)
+# Test: Text Input (Positional and -i Flag)
 
 ## Abstract
-Validates that --input auto-detects file paths vs direct text input.
+Validates that input works as positional argument and with -i flag, with auto-detection of file vs text.
 
 ## Prerequisites
 - `OPENAI_API_KEY` environment variable set
@@ -9,22 +9,34 @@ Validates that --input auto-detects file paths vs direct text input.
 
 ## Steps
 
-### 1. Text input (generate)
+### 1. Positional text input (generate)
+**Run:** `trickery generate "Tell me a short joke"`
+**Expect:** LLM response with a joke
+
+### 2. Flag text input (generate)
 **Run:** `trickery generate -i "Tell me a short joke"`
-**Expect:** LLM response with a joke (input treated as text since no such file exists)
+**Expect:** Same result as positional
 
-### 2. File input (generate)
+### 3. Positional file input (generate)
+**Run:** `trickery generate prompts/dad_jokes.md`
+**Expect:** LLM response based on file content
+
+### 4. Flag file input (generate)
 **Run:** `trickery generate -i prompts/dad_jokes.md`
-**Expect:** LLM response based on file content (file exists, so reads from it)
+**Expect:** Same result as positional file input
 
-### 3. Text input (image)
-**Run:** `trickery image -i "A simple red circle on white background" -s /tmp/test_circle.png`
+### 5. Positional text input (image)
+**Run:** `trickery image "A red circle" -s /tmp/test_circle.png`
 **Expect:** Image saved to /tmp/test_circle.png
 
-### 4. Multi-line text input
+### 6. Flag text input (image)
+**Run:** `trickery image -i "A red circle" -s /tmp/test_circle2.png`
+**Expect:** Image saved to /tmp/test_circle2.png
+
+### 7. Multi-line text input
 **Run:**
 ```bash
-trickery generate -i "You are a poet.
+trickery generate "You are a poet.
 
 Write a haiku about:
 - The moon
@@ -32,40 +44,34 @@ Write a haiku about:
 ```
 **Expect:** Haiku response
 
-### 5. Text with template variables
-**Run:** `trickery generate -i "Hello {{ name }}, you work at {{ company }}." --var name=Alice --var company=Acme`
-**Expect:** Response references "Alice" and "Acme"
+### 8. Positional with template variables
+**Run:** `trickery generate "Hello {{ name }}!" --var name=Alice`
+**Expect:** Response references "Alice"
 
-### 6. Long text input
+### 9. Long text input
 **Run:**
 ```bash
-trickery generate -i "$(cat <<'EOF'
-You are a technical writer. Please summarize the following:
+trickery generate "$(cat <<'EOF'
+You are a technical writer. Please summarize:
 
-1. Rust is a systems programming language focused on safety.
-2. It prevents null pointer exceptions through its ownership system.
-3. The borrow checker ensures memory safety at compile time.
-4. Cargo is the package manager and build system.
-5. Crates are Rust packages published to crates.io.
+1. Rust is a systems programming language.
+2. It prevents null pointer exceptions.
+3. Cargo is the package manager.
 
 Provide a 2-sentence summary.
 EOF
 )"
 ```
-**Expect:** 2-sentence summary of Rust features
+**Expect:** 2-sentence summary
 
-### 7. Error: missing --input
+### 10. Error: missing input
 **Run:** `trickery generate`
-**Expect:** Error about missing --input
+**Expect:** Error about missing input
 
-### 8. Image with text and auto-generated filename
-**Run:** `trickery image -i "Blue square"`
-**Expect:** Image saved to image-xxxxx.png (auto-generated filename, not based on input text)
-
-### 9. Text input with JSON output
-**Run:** `trickery generate -i "Say hello" -o json`
-**Expect:** JSON output with "output" field
-
-### 10. Text input with model selection
-**Run:** `trickery generate -i "Count to 5" -m gpt-4o-mini`
+### 11. Positional with model selection
+**Run:** `trickery generate "Count to 5" -m gpt-4o-mini`
 **Expect:** Response with numbers 1-5
+
+### 12. Positional with JSON output
+**Run:** `trickery generate "Say hello" -o json`
+**Expect:** JSON output with "output" field

--- a/test_cases/text_input.md
+++ b/test_cases/text_input.md
@@ -1,7 +1,7 @@
-# Test: Text Input (Positional and -i Flag)
+# Test: Text Input
 
 ## Abstract
-Validates that input works as positional argument and with -i flag, with auto-detection of file vs text.
+Validates that input works as positional argument with auto-detection of file vs text.
 
 ## Prerequisites
 - `OPENAI_API_KEY` environment variable set
@@ -13,27 +13,15 @@ Validates that input works as positional argument and with -i flag, with auto-de
 **Run:** `trickery generate "Tell me a short joke"`
 **Expect:** LLM response with a joke
 
-### 2. Flag text input (generate)
-**Run:** `trickery generate -i "Tell me a short joke"`
-**Expect:** Same result as positional
-
-### 3. Positional file input (generate)
+### 2. Positional file input (generate)
 **Run:** `trickery generate prompts/dad_jokes.md`
 **Expect:** LLM response based on file content
 
-### 4. Flag file input (generate)
-**Run:** `trickery generate -i prompts/dad_jokes.md`
-**Expect:** Same result as positional file input
-
-### 5. Positional text input (image)
+### 3. Positional text input (image)
 **Run:** `trickery image "A red circle" -s /tmp/test_circle.png`
 **Expect:** Image saved to /tmp/test_circle.png
 
-### 6. Flag text input (image)
-**Run:** `trickery image -i "A red circle" -s /tmp/test_circle2.png`
-**Expect:** Image saved to /tmp/test_circle2.png
-
-### 7. Multi-line text input
+### 4. Multi-line text input
 **Run:**
 ```bash
 trickery generate "You are a poet.
@@ -44,11 +32,11 @@ Write a haiku about:
 ```
 **Expect:** Haiku response
 
-### 8. Positional with template variables
+### 5. Positional with template variables
 **Run:** `trickery generate "Hello {{ name }}!" --var name=Alice`
 **Expect:** Response references "Alice"
 
-### 9. Long text input
+### 6. Long text input
 **Run:**
 ```bash
 trickery generate "$(cat <<'EOF'
@@ -64,14 +52,14 @@ EOF
 ```
 **Expect:** 2-sentence summary
 
-### 10. Error: missing input
+### 7. Error: missing input
 **Run:** `trickery generate`
 **Expect:** Error about missing input
 
-### 11. Positional with model selection
+### 8. Positional with model selection
 **Run:** `trickery generate "Count to 5" -m gpt-4o-mini`
 **Expect:** Response with numbers 1-5
 
-### 12. Positional with JSON output
+### 9. Positional with JSON output
 **Run:** `trickery generate "Say hello" -o json`
 **Expect:** JSON output with "output" field


### PR DESCRIPTION
## What
Add support for direct text input to `generate` and `image` commands without requiring a file. Input can now be provided as:
- Positional argument: `trickery generate "Your prompt here"`
- Flag argument: `trickery generate -i "Your prompt here"`
- File path (existing behavior): `trickery generate prompt.txt`

The input is auto-detected: if the value is an existing file path, it reads the file; otherwise, it treats it as direct text.

## Why
Users often want to run quick one-off prompts without creating temporary files. This is especially useful in CI/CD pipelines and shell scripts where inline prompts are more convenient.

## How
- Added `resolve_input()` function that checks if input path exists (reads file) or not (uses as text)
- Implemented dual input capture with positional and `-i` flag arguments
- Updated `generate_output_filename()` to handle text input (defaults to "image" stem)
- Added `override_usage` for cleaner help display showing `[INPUT] [OPTIONS]`

## Risk
- Low
- Existing file-based workflows unchanged; auto-detection only falls back to text if path doesn't exist

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated (specs/text-input.md, test_cases/text_input.md)
