### PR TITLE
chore: update Cargo.lock for v0.1.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ CI is implemented using GitHub Actions (`.github/workflows/ci.yaml`):
 3. Tests: Ensure `cargo test` passes
 4. Build: Ensure `cargo build` succeeds
 5. Full help: If CLI options changed, update `print_full_help()` in `src/main.rs`
+6. Lockfile: Run `cargo update --workspace` after version bumps or dependency changes to sync Cargo.lock
 
 ## Commit message conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "trickery"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
  "clap",


### PR DESCRIPTION
## What
Update Cargo.lock to reflect version 0.1.3.

## Why
`cargo publish` failed because Cargo.lock still referenced v0.1.2 while Cargo.toml was bumped to v0.1.3, causing uncommitted changes during publish.

## How
Ran `cargo update --workspace` to sync the lockfile.

## Risk
- Low
- No functional changes, only lockfile sync

### Checklist
- [x] Unit tests are passed
- [x] Smoke tests are passed
- [x] Documentation is updated
