### PR TITLE
docs: clarify agent-friendly badge refers to repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Coding Agent friendly tool to magically generate text and images.
 
 [![CI](https://github.com/chaliy/trickery/actions/workflows/ci.yaml/badge.svg)](https://github.com/chaliy/trickery/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/trickery)](https://crates.io/crates/trickery)
-[![Coding Agent Friendly](https://img.shields.io/badge/coding%20agent-friendly-brightgreen)](specs/coding-agent-design.md)
+[![Tool: Agent Friendly](https://img.shields.io/badge/tool-agent%20friendly-brightgreen)](specs/coding-agent-design.md)
+[![Repo: Agent Friendly](https://img.shields.io/badge/repo-agent%20friendly-blue)](AGENTS.md)
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Coding Agent friendly tool to magically generate text and images.
 
 [![CI](https://github.com/chaliy/trickery/actions/workflows/ci.yaml/badge.svg)](https://github.com/chaliy/trickery/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/trickery)](https://crates.io/crates/trickery)
-[![Tool: Agent Friendly](https://img.shields.io/badge/tool-agent%20friendly-brightgreen)](specs/coding-agent-design.md)
 [![Repo: Agent Friendly](https://img.shields.io/badge/repo-agent%20friendly-blue)](AGENTS.md)
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)

--- a/prompts/trickery_readme.md
+++ b/prompts/trickery_readme.md
@@ -14,7 +14,6 @@ Coding Agent friendly tool to magically generate text and images.
 
 [![CI](https://github.com/chaliy/trickery/actions/workflows/ci.yaml/badge.svg)](https://github.com/chaliy/trickery/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/trickery)](https://crates.io/crates/trickery)
-[![Tool: Agent Friendly](https://img.shields.io/badge/tool-agent%20friendly-brightgreen)](specs/coding-agent-design.md)
 [![Repo: Agent Friendly](https://img.shields.io/badge/repo-agent%20friendly-blue)](AGENTS.md)
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)

--- a/prompts/trickery_readme.md
+++ b/prompts/trickery_readme.md
@@ -14,7 +14,8 @@ Coding Agent friendly tool to magically generate text and images.
 
 [![CI](https://github.com/chaliy/trickery/actions/workflows/ci.yaml/badge.svg)](https://github.com/chaliy/trickery/actions/workflows/ci.yaml)
 [![Crates.io](https://img.shields.io/crates/v/trickery)](https://crates.io/crates/trickery)
-[![Coding Agent Friendly](https://img.shields.io/badge/coding%20agent-friendly-brightgreen)](specs/coding-agent-design.md)
+[![Tool: Agent Friendly](https://img.shields.io/badge/tool-agent%20friendly-brightgreen)](specs/coding-agent-design.md)
+[![Repo: Agent Friendly](https://img.shields.io/badge/repo-agent%20friendly-blue)](AGENTS.md)
 
 [![Stand With Ukraine](https://raw.githubusercontent.com/vshymanskyy/StandWithUkraine/main/banner2-direct.svg)](https://vshymanskyy.github.io/StandWithUkraine/)
 


### PR DESCRIPTION
## What
Replace generic "Coding Agent Friendly" badge with "Repo: Agent Friendly" badge that links to AGENTS.md.

## Why
Clarify that the badge indicates the **repository** is structured for coding agents (clear docs, AGENTS.md guidance, test cases), not just that the tool itself is agent-friendly.

## How
- Updated badge text from "coding agent friendly" to "repo agent friendly"
- Changed link target from `specs/coding-agent-design.md` to `AGENTS.md`
- Applied to both README.md and template

## Risk
- Low
- Documentation only, no code changes
