### PR TITLE
chore: standardize PR descriptions on functional change + before/after

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## What changed
+Describe the change functionally — what behavior changes and its impact on users
+or callers. Lead with outcomes; don't walk through code locations, the diff shows
+where and how. Keep any code-level notes short and specific.
+
+## Why
+Problem or motivation.
+
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI/API output, logs, metrics, or screenshots for UI (attach working screenshots
+when possible). For changes with no observable behavior (pure refactor, docs), say so.
+
+## Risk
+- Low / Medium / High
+- What can break
+
+### Checklist
+- [ ] Unit tests are passed
+- [ ] Smoke tests are passed
+- [ ] Documentation is updated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,17 +99,26 @@ Follow Conventional Commits format:
 
 PR titles should follow Conventional Commits format: `<type>[optional scope]: <description>`
 
+Center the description on functional change and impact, not a code-location
+walkthrough (the diff shows that). Add a Before / After with proof — CLI output,
+logs, or screenshots for UI — whenever behavior changes. The repo ships a matching
+`.github/pull_request_template.md`.
+
 ### PR body template
 
 ```markdown
-## What
-Clear description of the change.
+## What changed
+Describe the change functionally — what behavior changes and its impact. Lead with
+outcomes; don't walk through code locations, the diff shows where and how. Keep any
+code-level notes short and specific.
 
 ## Why
 Problem or motivation.
 
-## How
-High-level approach.
+## Before / After
+Show the effect with evidence. Include before and after whenever behavior changes —
+CLI output, logs, or screenshots for UI (attach working screenshots when possible).
+For changes with no observable behavior (pure refactor, docs), say so.
 
 ## Risk
 - Low / Medium / High


### PR DESCRIPTION
## What changed

PR descriptions now center on **functional change and impact** instead of a code-location walkthrough, and the repo gains a `.github/pull_request_template.md` with a **Before / After** section that asks for proof — CLI output, logs, or screenshots for UI. The inline PR-body template in `AGENTS.md` is updated to match.

## Why

The diff already shows *where* and *how* code changed. A description should add what the diff can't: the behavior that changed, who it affects, and evidence it works — shifting effort from restating code to demonstrating impact.

## Before / After

Docs/templates only — no runtime behavior changes.

- **Before:** no PR template; inline body used `## What` / `## How`.
- **After:** `## What changed` (functional summary + impact) + `## Before / After` (proof: output/logs, screenshots for UI when possible); template file now exists and matches `AGENTS.md`.

## Risk

- Low
- Documentation and PR-template only; no source, config, or CI logic touched.

## Checklist

- [x] Unit tests are passed — N/A (docs/templates only)
- [x] Smoke tests are passed — N/A
- [x] Documentation is updated

---
_Generated by [Claude Code](https://claude.ai/code/session_013LSB82Db25Rf3tVPqWb1JQ)_